### PR TITLE
Add check of elasticsearch routing allocation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     tests_require=[
         "nose >=1.3, <1.4",
-        "freezegun==0.1.11",
+        "freezegun==0.3.3",
         "httpretty==0.8.3"
     ],
 


### PR DESCRIPTION
Checks if routing allocation has been disabled (in the way that our
fabric task disables it) and raises a critical if so.

If the keys in cluster status do not exist, we assume routing allocation
is not disabled and do not raise an alert.

This is an unsatisfying check, because it will default to being a false
pass if elasticsearch changes its API, and can also pass if allocation
is disabled with some other deprecated settings (eg, by setting
cluster.routing.allocation.disable_allocation).

However, because the keys don't exist in the index settings API unless
allocation has been disabled since the cluster started up, we can't
require the keys to be present.  There's also no way to check
elasticsearches "view" of what a particular configuration setting is
(there's no abstraction layer in elasticsearch which interprets and
validates settings - they're just consumed throughout the elasticsearch
app and validated on consumption).

In the absence of a way to make the default be "fail", this check that
we've not accidentally left allocation disabled is better than nothing.

This is based on some initial work by Tim Mower.